### PR TITLE
Remove static_labels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='tornado-prometheus-exporter',
-    version='0.0.1',
+    version='0.0.2',
     packages=find_packages(),
     url='https://github.com/FRI-DAY/tornado-prometheus-exporter',
     license='MIT',

--- a/tornado_prometheus_exporter/__init__.py
+++ b/tornado_prometheus_exporter/__init__.py
@@ -11,8 +11,6 @@ class Application(_Application):
     """ Adds Prometheus integration to Tornado """
     def __init__(self, *args, **kwargs):
         """
-        :param prometheus_static_labels: Labels that get statically applied to
-            the generated metrics.
         :param prometheus_registry: Prometheus registry that metrics are
             registered to.
         :param int prometheus_port: If not None, start prometheus server with
@@ -21,15 +19,13 @@ class Application(_Application):
         """
         super(Application, self).__init__(*args, **kwargs)
 
-        self.static_labels = kwargs.pop('static_labels', {})
         self.registry = kwargs.pop('registry', DEFAULT_REGISTRY)
 
         port = kwargs.pop('prometheus_port', None)
         buckets = kwargs.pop('prometheus_buckets', None)
 
-        default_labels = ['handler', 'method', 'status']
         histogram_kwargs = {
-            'labelnames': default_labels + list(self.static_labels.keys()),
+            'labelnames': ['handler', 'method', 'status'],
             'registry': self.registry,
         }
         if buckets is not None:
@@ -50,6 +46,5 @@ class Application(_Application):
             .labels(
                 handler=type(handler).__name__.lower(),
                 method=handler.request.method.lower(),
-                status=int(handler.get_status()),
-                **self.static_labels) \
+                status=int(handler.get_status())) \
             .observe(handler.request.request_time())


### PR DESCRIPTION
The feature may be confusing because the default platform metrics that
are added by the `prometheus_client` library are not changed. This is
intended because those being added are just a side-effect of using the
library.

However, in our use case, we noticed that we don't need those static
labels and rater let outside means (prometheus, kubernetes) add them on
scraping.

No version increment by 1 because the library is alpha anyways and not
published to PyPi